### PR TITLE
Optimizations, vehicles fix, and heading change

### DIFF
--- a/fivem_script/tokovoip_script/c_config.lua
+++ b/fivem_script/tokovoip_script/c_config.lua
@@ -8,6 +8,7 @@ TokoVoipConfig = {
 		5, -- Whisper speech distance in gta distance units
 		40, -- Shout speech distance in gta distance units
 	},
+	headingType = 0, -- headingType 0 uses GetGameplayCamRot, basing heading on the camera's heading, to match how other GTA sounds work. headingType 1 uses GetEntityHeading which is based on the character's direction
 	radioKey = Keys["CAPS"], -- Keybind used to talk on the radio
 	keySwitchChannels = Keys["Z"], -- Keybind used to switch the radio channels
 	keySwitchChannelsSecondary = Keys["LEFTSHIFT"], -- If set, both the keySwitchChannels and keySwitchChannelsSecondary keybinds must be pressed to switch the radio channels

--- a/fivem_script/tokovoip_script/src/c_main.lua
+++ b/fivem_script/tokovoip_script/src/c_main.lua
@@ -37,12 +37,13 @@ function initializeVoip()
 	voip.myChannels = {};
 
 	-- Player data shared on the network
-	setPlayerData(GetPlayerName(PlayerId()), "voip:mode", voip.mode, true);
-	setPlayerData(GetPlayerName(PlayerId()), "voip:talking", voip.talking, true);
-	setPlayerData(GetPlayerName(PlayerId()), "radio:channel", voip.plugin_data.radioChannel, true);
-	setPlayerData(GetPlayerName(PlayerId()), "radio:talking", voip.plugin_data.radioTalking, true);
-	setPlayerData(GetPlayerName(PlayerId()), "voip:pluginStatus", voip.pluginStatus, true);
-	setPlayerData(GetPlayerName(PlayerId()), "voip:pluginVersion", voip.pluginVersion, true);
+	playername = GetPlayerName(PlayerId())
+	setPlayerData(playername, "voip:mode", voip.mode, true);
+	setPlayerData(playername, "voip:talking", voip.talking, true);
+	setPlayerData(playername, "radio:channel", voip.plugin_data.radioChannel, true);
+	setPlayerData(playername, "radio:talking", voip.plugin_data.radioTalking, true);
+	setPlayerData(playername, "voip:pluginStatus", voip.pluginStatus, true);
+	setPlayerData(playername, "voip:pluginVersion", voip.pluginVersion, true);
 
 	-- Set targetped (used for spectator mod for admins)
 	targetPed = GetPlayerPed(-1);

--- a/fivem_script/tokovoip_script/src/c_main.lua
+++ b/fivem_script/tokovoip_script/src/c_main.lua
@@ -141,18 +141,19 @@ function clientProcessing()
 		local usersdata = {};
 		local localHeading = math.rad(GetGameplayCamRot().z % 360);
 		local localPos;
+		local HeadBone = 0x796e
 
 		if useLocalPed then
-			localPos = GetEntityCoords(GetPlayerPed(-1));
+			localPos = GetPedBoneCoords(GetPlayerPed(-1), HeadBone)
 		else
-			localPos = GetEntityCoords(targetPed);
+			localPos = GetPedBoneCoords(targetPed, HeadBone)
 		end
 
 		for i = 1, #playerList do
 			local player = playerList[i];
 				if (GetPlayerPed(-1) and GetPlayerPed(player)) then
+					local playerPos = GetPedBoneCoords(GetPlayerPed(player), HeadBone)
 
-					local playerPos = GetEntityCoords(GetPlayerPed(player));
 					local dist = #(localPos - playerPos)
 
 					if (not getPlayerData(GetPlayerName(player), "voip:mode")) then

--- a/fivem_script/tokovoip_script/src/c_main.lua
+++ b/fivem_script/tokovoip_script/src/c_main.lua
@@ -139,7 +139,12 @@ AddEventHandler("onClientResourceStart", resourceStart);
 function clientProcessing()
 		local playerList = voip.playerList;
 		local usersdata = {};
-		local localHeading = math.rad(GetGameplayCamRot().z % 360);
+		local localHeading;
+		if (voip.headingType == 1) then
+			localHeading = math.rad(GetEntityHeading(GetPlayerPed(-1)));
+		else
+			localHeading = math.rad(GetGameplayCamRot().z % 360);
+		end
 		local localPos;
 		local HeadBone = 0x796e;
 
@@ -152,7 +157,7 @@ function clientProcessing()
 		for i = 1, #playerList do
 			local player = playerList[i];
 				if (GetPlayerPed(-1) and GetPlayerPed(player)) then
-				
+
 					local playerPos = GetPedBoneCoords(GetPlayerPed(player), HeadBone);
 					local dist = #(localPos - playerPos);
 

--- a/fivem_script/tokovoip_script/src/c_main.lua
+++ b/fivem_script/tokovoip_script/src/c_main.lua
@@ -141,20 +141,20 @@ function clientProcessing()
 		local usersdata = {};
 		local localHeading = math.rad(GetGameplayCamRot().z % 360);
 		local localPos;
-		local HeadBone = 0x796e
+		local HeadBone = 0x796e;
 
 		if useLocalPed then
-			localPos = GetPedBoneCoords(GetPlayerPed(-1), HeadBone)
+			localPos = GetPedBoneCoords(GetPlayerPed(-1), HeadBone);
 		else
-			localPos = GetPedBoneCoords(targetPed, HeadBone)
+			localPos = GetPedBoneCoords(targetPed, HeadBone);
 		end
 
 		for i = 1, #playerList do
 			local player = playerList[i];
 				if (GetPlayerPed(-1) and GetPlayerPed(player)) then
-					local playerPos = GetPedBoneCoords(GetPlayerPed(player), HeadBone)
-
-					local dist = #(localPos - playerPos)
+				
+					local playerPos = GetPedBoneCoords(GetPlayerPed(player), HeadBone);
+					local dist = #(localPos - playerPos);
 
 					if (not getPlayerData(GetPlayerName(player), "voip:mode")) then
 						setPlayerData(GetPlayerName(player), "voip:mode", 1);

--- a/fivem_script/tokovoip_script/src/c_main.lua
+++ b/fivem_script/tokovoip_script/src/c_main.lua
@@ -153,7 +153,7 @@ function clientProcessing()
 				if (GetPlayerPed(-1) and GetPlayerPed(player)) then
 
 					local playerPos = GetEntityCoords(GetPlayerPed(player));
-					local dist = GetDistanceBetweenCoords(localPos, playerPos, true);
+					local dist = #(localPos - playerPos)
 
 					if (not getPlayerData(GetPlayerName(player), "voip:mode")) then
 						setPlayerData(GetPlayerName(player), "voip:mode", 1);

--- a/fivem_script/tokovoip_script/src/c_main.lua
+++ b/fivem_script/tokovoip_script/src/c_main.lua
@@ -37,7 +37,7 @@ function initializeVoip()
 	voip.myChannels = {};
 
 	-- Player data shared on the network
-	playername = GetPlayerName(PlayerId())
+	playername = GetPlayerName(PlayerId());
 	setPlayerData(playername, "voip:mode", voip.mode, true);
 	setPlayerData(playername, "voip:talking", voip.talking, true);
 	setPlayerData(playername, "radio:channel", voip.plugin_data.radioChannel, true);
@@ -139,7 +139,7 @@ AddEventHandler("onClientResourceStart", resourceStart);
 function clientProcessing()
 		local playerList = voip.playerList;
 		local usersdata = {};
-		local localHeading = math.rad(GetEntityHeading(GetPlayerPed(-1)));
+		local localHeading = math.rad(GetGameplayCamRot().z % 360);
 		local localPos;
 
 		if useLocalPed then


### PR DESCRIPTION
This PR involves 3 small changes

1. General optimizations, like using lua vectors to calculate distance instead of the slow GetDistanceBetweenCoords native call, and also refactoring values into variables so natives aren't being unnecessarily called multiple times

2. Fix for directional audio in vehicles. GTA/FiveM will return the vehicle's position when GetEntityCoords is called on a ped, if that ped is in the vehicle. Because of this, when in a vehicle, everyone sounded like they were inside each other. Also, people outside the vehicle would hear people from the wrong location. This was fixed by using GetPedBoneCoords to track the ped's position to their head bone. This is also more accurate in general, and allows for accurate positional audio when doing things like laying prone. See the picture below for a demonstration of this (the blue marker is the head bone position, and the red marker is the position returned by GetEntityCoords).
![image](https://user-images.githubusercontent.com/1360790/59748989-33743600-924a-11e9-8ce3-d893ead41baa.png)
Now if you're the driver for example, the front passenger is heard to your right, the back left passenger is heard behind you, etc. This works for all vehicle types and even custom positions like riding in the trunk.

3. Switched the player heading, used for calculating the directional audio, to be based on the camera heading and not their player model's heading. This follows how the rest of GTA's audio works, which is always based on camera heading.

These changes have already been given to and are being tested by Nopixel and you can hear the changes in this vod starting from the timecode in the url: https://www.twitch.tv/videos/441008528?t=05h20m27s