### PR TITLE
Set resource_manifiest_version

### DIFF
--- a/fivem_script/tokovoip_script/__resource.lua
+++ b/fivem_script/tokovoip_script/__resource.lua
@@ -1,3 +1,5 @@
+resource_manifest_version '44febabe-d386-4d18-afbe-5e627f4af937'
+
 client_script "src/c_utils.lua"
 client_script "c_config.lua"
 client_script "src/c_main.lua"


### PR DESCRIPTION
This fixes the issue where `GetGameplayCamRot()` currently returns an integer rather than a vector in later versions of the FiveM client.

It's been previously reported in #31