### PR TITLE
Resolve initialization problems for some players

### DIFF
--- a/fivem_script/tokovoip_script/nui/script.js
+++ b/fivem_script/tokovoip_script/nui/script.js
@@ -85,7 +85,6 @@ async function init(address, serverId) {
 	await updateClientIP(endpoint);
 	console.log('TokoVOIP: attempt new connection');
 	websocket = new WebSocket(`ws://${endpoint}/socket.io/?EIO=3&transport=websocket&from=fivem&serverId=${serverId}`);
-	console.log('[TokoVOIP] : Websocket object built', websocket)
 
 	websocket.onopen = () => {
 		updateWsState('FiveM', OK)
@@ -123,7 +122,6 @@ async function init(address, serverId) {
 	};
 
 	websocket.onerror = (evt) => {
-		console.log(`[TokoVOIP] : Error on websocket :`, evt)
 		console.error('TokoVOIP: error - ' + evt.data);
 	};
 
@@ -182,7 +180,6 @@ function receivedClientCall (event) {
 
 	// Start with a status OK by default, and change the status if issues are encountered
 	voipStatus = OK;
-	console.log('[TokoVOIP] Received client call with payload ', payload)
 	if (eventName == 'updateConfig') {
 		updateConfig(payload);
 

--- a/fivem_script/tokovoip_script/src/c_TokoVoip.lua
+++ b/fivem_script/tokovoip_script/src/c_TokoVoip.lua
@@ -101,7 +101,6 @@ end
 function TokoVoip.initialize(self)
 	self:updateConfig();
 	self:updatePlugin("initializeSocket", self.wsServer);
-	print('[TokoVOIP] Client : NUI event sent to initialize websocket')
 	Citizen.CreateThread(function()
 		while (true) do
 			Citizen.Wait(5);

--- a/ws_server/index.js
+++ b/ws_server/index.js
@@ -112,7 +112,6 @@ io.on('connection', async socket => {
   socket.from = socket.request._query.from;
   socket.clientIp = socket.handshake.headers['x-forwarded-for'] || socket.request.connection.remoteAddress.replace('::ffff:', '');
   socket.safeIp = Buffer.from(socket.clientIp).toString('base64');
-  console.log(`[TokoVOIP] : IP ${socket.safeIp} successfully joined websocket`);
   if (socket.clientIp.includes('::1') || socket.clientIp.includes('127.0.0.1') || socket.clientIp.includes('192.168.')) socket.clientIp = hostIP;
   socket.fivemServerId = socket.request._query.serverId;
 
@@ -126,7 +125,6 @@ io.on('connection', async socket => {
     socket.uuid = socket.request._query.uuid;
 
     if (!handshakes[socket.clientIp]) {
-      console.log(`[TokoVOIP] : Handshake not found for IP ${socket.clientIp}`)
       socket.emit('disconnectMessage', 'handshakeNotFound');
       socket.disconnect(true);
       return;
@@ -145,7 +143,6 @@ io.on('connection', async socket => {
     client.ts3.linkedAt = (new Date()).toISOString();
     delete handshakes[socket.clientIp];
 
-    console.log(`[TokoVOIP] : Handshake successfull for IP ${socket.clientIp}`)
     log('log', chalk`{${socket.from === 'ts3' ? 'cyan' : 'yellow'} ${socket.from}} | Handshake {green successful} - ${socket.safeIp}`);
 
     socket.on('setTS3Data', data => setTS3Data(socket, data));
@@ -188,7 +185,6 @@ async function registerHandshake(socket) {
         },
       });
     } catch (e) {
-      console.log(`[TokoVOIP] : Cannot register handshake for IP ${socket.clientIp} (Axios error on master)`)
       console.error(e);
       throw e;
     }


### PR DESCRIPTION
# Related issues

#202 
#195 
#191 
#189 
#182 
#158 

# Bug explanation

- I found an initialization problem. Indeed some players could not have a connection with the websocket server.
This error is due to the hardware configuration of users. Small processors take longer to load resources and therefore NUI is loaded after TokoVOIP initialization. The script.js file is not loaded and the connection to the websocket server is not initiated.

- The getmyip and upgrade routes of the websocket server were poorly defined

# Fixes

- Add an "nuiLoaded" nui callback in client main, trigerred by script.js on initialisation. 
- Loop on voip:initialisation to load script.js file when nui is loaded and trigger nuiLoaded event
- Add '/' before routes names for getmyip and upgrade, to prevent a fail during ip update and upgrade route call

# Tests

I tested this version during an evening with around 50-60 players, all players who couldn't log in, can now use the plugin without problems